### PR TITLE
Update plugin.py

### DIFF
--- a/hatch_build_scripts/plugin.py
+++ b/hatch_build_scripts/plugin.py
@@ -57,7 +57,7 @@ class BuildScriptsHook(BuildHookInterface):
                 log.debug(f"Copying {src_file} to {out_file}")
                 if src_file not in created:
                     out_file.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copyfile(src_file, out_file)
+                    shutil.copy2(src_file, out_file)
                     created.add(out_file)
                 else:
                     log.debug(f"Skipping {src_file} - already exists")


### PR DESCRIPTION
Currently copying artifacts from the working directory to the out directory does not preserve metadata like permissions or extended attributes. This can be particularly problematic for the executable bit.

## Issues

<!-- Link the issues this change resolves, or describe them -->

## Summary

<!-- Describe how these changes resolve the aforementioned issues -->
